### PR TITLE
SDP-11731 【DeepTunnel】wireguard-windows适配wireguard-go的应用场景

### DIFF
--- a/tunnel/watcher.go
+++ b/tunnel/watcher.go
@@ -1,0 +1,32 @@
+package tunnel
+
+import (
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/windows/conf"
+)
+
+type Watcher struct {
+	watcher *interfaceWatcher
+}
+
+func NewWatcher() *Watcher {
+	w, err := watchInterface()
+	if err != nil {
+		return nil
+	}
+	return &Watcher{
+		watcher: w,
+	}
+}
+
+func (w *Watcher) Run(dev *device.Device, conf *conf.Config, tun *tun.NativeTun) {
+	w.watcher.Configure(dev, conf, tun)
+}
+
+func (w *Watcher) Close() {
+	if w.watcher != nil {
+		w.watcher.Destroy()
+		w.watcher = nil
+	}
+}


### PR DESCRIPTION
【现象】：windows下使用wireguard-go需要依赖wireguard-windows库的内容，需要依赖的内容属于private，外界不能直接使用import
【原因】：新功能开发
【方案】：在wireguard-windows的tunnel中增加一个文件，定义导出对外的接口